### PR TITLE
Use `ui_component` view helper

### DIFF
--- a/app/cells/checkbox_list_cell.rb
+++ b/app/cells/checkbox_list_cell.rb
@@ -17,7 +17,7 @@ class CheckboxListCell < Cell::ViewModel
 
   def boxes
     options[:values].map do |value|
-      model.check_box(options[:name], { multiple: true, label: label(value) }, value, nil)
+      options[:form].check_box(options[:name], { multiple: true, label: label(value) }, value, nil)
     end
   end
 

--- a/app/cells/date_range_cell.rb
+++ b/app/cells/date_range_cell.rb
@@ -10,7 +10,7 @@ class DateRangeCell < FormCellBase
   private
 
   def date_field(type)
-    model.text_field(
+    options[:form].text_field(
       "#{options[:name]}_#{type}",
       id: "#{id}_#{type}",
       skip_label: true,
@@ -19,7 +19,7 @@ class DateRangeCell < FormCellBase
   end
 
   def select_div
-    model.send(:form_group_builder, :daterange, label: label) do
+    options[:form].send(:form_group_builder, :daterange, label: label) do
       content_tag(
         :div,
         '',

--- a/app/cells/select_cell.rb
+++ b/app/cells/select_cell.rb
@@ -1,6 +1,6 @@
 class SelectCell < FormCellBase
   def show
-    model.select(
+    options[:form].select(
       options[:name],
       options_for_select(select_options),
       { label: label },

--- a/app/helpers/ui_components/view_helper.rb
+++ b/app/helpers/ui_components/view_helper.rb
@@ -1,8 +1,7 @@
 module UiComponents
   module ViewHelper
     def ui_component(name, options = {})
-      component = Component.by_name(name).new(options)
-      render "ui_components/#{name}", component: component
+      cell(name.to_sym, nil, options).call
     end
   end
 end

--- a/spec/dummy/app/views/components/checkbox_list.slim
+++ b/spec/dummy/app/views/components/checkbox_list.slim
@@ -1,2 +1,2 @@
 = bootstrap_form_for :fox do |form|
-  = cell(:checkbox_list, form, name: 'list', values: %w(apple banana kiwi)).call
+  = ui_component(:checkbox_list, form: form, name: 'list', values: %w(apple banana kiwi))

--- a/spec/dummy/app/views/components/date_range.html.slim
+++ b/spec/dummy/app/views/components/date_range.html.slim
@@ -1,2 +1,2 @@
 = bootstrap_form_for :fox do |form|
-  = cell(:date_range, form, name: 'report_range').call
+  = ui_component(:date_range, form: form, name: 'report_range')

--- a/spec/dummy/app/views/components/select.html.slim
+++ b/spec/dummy/app/views/components/select.html.slim
@@ -1,3 +1,3 @@
 = bootstrap_form_for :fox do |form|
-  = cell(:select, form, name: 'type_id', \
-    options: [['Red', 1], ['Fennec', 2], ['Arctic', 3]]).call
+  = ui_component(:select, form: form, name: 'type_id', \
+    options: [['Red', 1], ['Fennec', 2], ['Arctic', 3]])


### PR DESCRIPTION
In order to hide the implementation details we should use the `ui_component` helper method as the only interface.