### PR TITLE
Modal component individually tested

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ A component consists of a bunch of files in a single directory in
 ## TODO
 
 * Move requiring of dependencies into individual components' JS and add
-  tests.
+  tests (take a look at the modal component to see how).
+* When updating to SASS 4, CSS should also be moved into the components'
+  directories.
 * Add types to attribute definitions in cells.
 * Get rid of `UiComponents::FormHelper`.

--- a/app/cells/modal/modal.coffee
+++ b/app/cells/modal/modal.coffee
@@ -1,0 +1,2 @@
+#= require jquery
+#= require bootstrap/modal

--- a/app/cells/modal/modal.coffee
+++ b/app/cells/modal/modal.coffee
@@ -1,2 +1,2 @@
 #= require jquery
-#= require bootstrap/modal
+#= require bootstrap

--- a/app/cells/modal/modal.scss
+++ b/app/cells/modal/modal.scss
@@ -1,1 +1,0 @@
-@import 'bootstrap';

--- a/app/cells/modal/modal.scss
+++ b/app/cells/modal/modal.scss
@@ -1,0 +1,1 @@
+@import 'bootstrap';

--- a/app/cells/modal/modal.slim
+++ b/app/cells/modal/modal.slim
@@ -1,0 +1,12 @@
+.modal.fade id=id
+  .modal-dialog
+    .modal-content
+      .modal-header
+        button.close aria-label="Close" data-dismiss="modal" type="button" 
+          span aria-hidden="true"  &times;
+        h4.modal-title= title
+      .modal-body
+        p= content
+      - if buttons
+        .modal-footer
+          = buttons

--- a/app/cells/modal/modal.slim
+++ b/app/cells/modal/modal.slim
@@ -2,7 +2,7 @@
   .modal-dialog
     .modal-content
       .modal-header
-        button.close aria-label="Close" data-dismiss="modal" type="button" 
+        button.close aria-label="Close" data-dismiss="modal" type="button"
           span aria-hidden="true"  &times;
         h4.modal-title= title
       .modal-body

--- a/app/cells/modal/modal.yml
+++ b/app/cells/modal/modal.yml
@@ -1,0 +1,23 @@
+description: "I didn't change the default description."
+examples:
+  - description: 'A simple modal.'
+    slim: |
+      = ui_component 'modal', id: 'alice',
+                              title: "Hello!",
+                              content: "'If you knew Time as well as I do,' said the Hatter, " \
+                                       "'you wouldn't talk about wasting IT. It's HIM.'"
+
+      button data-toggle="modal" data-target="#alice"
+        = 'Click me!'
+
+  - description: 'A modal with buttons.'
+    slim: |
+      = ui_component 'modal', id: 'hatter',
+                              title: "Hello!",
+                              content: "'If you knew Time as well as I do,' said the Hatter, " \
+                                       "'you wouldn't talk about wasting IT. It's HIM.'",
+                              buttons: [:close, :submit]
+
+      button data-toggle="modal" data-target="#hatter"
+        = 'Click me!'
+

--- a/app/cells/modal/modal_cell.rb
+++ b/app/cells/modal/modal_cell.rb
@@ -25,8 +25,6 @@ class ModalCell < UiComponents::Cell
   end
 
   def submit_button
-    tag('input', type: 'submit',
-                 class: 'btn btn-primary',
-                 value: I18n.t('ui_components.modal.save'))
+    submit_tag(I18n.t('ui_components.modal.save'), class: 'btn btn-primary')
   end
 end

--- a/app/cells/modal/modal_cell.rb
+++ b/app/cells/modal/modal_cell.rb
@@ -1,0 +1,21 @@
+class ModalCell < UiComponents::Cell
+  attribute :id, mandatory: true, description: 'The HTML id attribute.'
+  attribute :content, mandatory: true, description: "The modal's content."
+  attribute :title, description: 'A title.'
+  attribute :buttons, description: 'An array of button types. Valid types are `:close` and `:save`.'
+
+  private
+
+  def buttons
+    @buttons.try(:map) do |button|
+      case button
+      when :close
+        content_tag('button', type: 'button', class: 'btn btn-default', data: { dismiss: 'modal' }) do
+          'Close'
+        end
+      when :submit
+        tag('input', type: 'submit', class: 'btn btn-primary', value: 'Save')
+      end
+    end.try(:join)
+  end
+end

--- a/app/cells/modal/modal_cell.rb
+++ b/app/cells/modal/modal_cell.rb
@@ -2,7 +2,8 @@ class ModalCell < UiComponents::Cell
   attribute :id, mandatory: true, description: 'The HTML id attribute.'
   attribute :content, mandatory: true, description: "The modal's content."
   attribute :title, description: 'A title.'
-  attribute :buttons, description: 'An array of button types. Valid types are `:close` and `:save`.'
+  attribute :buttons, description: 'An array of button types. ' \
+                                   'Valid types are `:close` and `:submit`.'
 
   private
 

--- a/app/cells/modal/modal_cell.rb
+++ b/app/cells/modal/modal_cell.rb
@@ -9,13 +9,22 @@ class ModalCell < UiComponents::Cell
   def buttons
     @buttons.try(:map) do |button|
       case button
-      when :close
-        content_tag('button', type: 'button', class: 'btn btn-default', data: { dismiss: 'modal' }) do
-          'Close'
-        end
-      when :submit
-        tag('input', type: 'submit', class: 'btn btn-primary', value: 'Save')
+      when :close then close_button
+      when :submit then submit_button
+      else fail "'#{button}' button not implemented"
       end
     end.try(:join)
+  end
+
+  def close_button
+    content_tag('button', class: 'btn btn-default', data: { dismiss: 'modal' }) do
+      I18n.t('ui_components.modal.close')
+    end
+  end
+
+  def submit_button
+    tag('input', type: 'submit',
+                 class: 'btn btn-primary',
+                 value: I18n.t('ui_components.modal.save'))
   end
 end

--- a/app/cells/modal/modal_cell.rb
+++ b/app/cells/modal/modal_cell.rb
@@ -8,13 +8,14 @@ class ModalCell < UiComponents::Cell
   private
 
   def buttons
-    @buttons.try(:map) do |button|
+    return unless @buttons
+    @buttons.map do |button|
       case button
       when :close then close_button
       when :submit then submit_button
       else fail "'#{button}' button not implemented"
       end
-    end.try(:join)
+    end.join
   end
 
   def close_button

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,9 @@ en:
     markdown_textarea_cell:
       edit: Edit
       preview: Preview
+    modal:
+      close: Close
+      save: Save
   styleguide:
     components:
       foo:

--- a/lib/ui_components/engine.rb
+++ b/lib/ui_components/engine.rb
@@ -7,6 +7,11 @@ module UiComponents
     initializer 'ui_components.assets.precompile' do |app|
       app.config.assets.precompile += %w(styleguide.js
                                          styleguide.css)
+      app.config.assets.precompile +=
+        self.class.components_paths
+          .map(&:basename)
+          .map { |p| ["#{p}.js", "#{p}.css"] }
+          .flatten
     end
 
     def self.components_paths

--- a/spec/dummy/app/controllers/components_controller.rb
+++ b/spec/dummy/app/controllers/components_controller.rb
@@ -2,4 +2,17 @@ class ComponentsController < ApplicationController
   def show
     render params[:name]
   end
+
+  def new_show
+    component_class = "#{params.require(:name)}_cell".camelize.constantize
+    @example = component_class.examples[example_index]
+    fail "Example #{example_index} not found" unless @example
+    render layout: 'single_component'
+  end
+
+  private
+
+  def example_index
+    params.require(:example_index).to_i
+  end
 end

--- a/spec/dummy/app/views/components/new_show.slim
+++ b/spec/dummy/app/views/components/new_show.slim
@@ -1,0 +1,1 @@
+= ui_component_execute_example_call(params.require(:name), @example)

--- a/spec/dummy/app/views/layouts/single_component.slim
+++ b/spec/dummy/app/views/layouts/single_component.slim
@@ -1,0 +1,10 @@
+doctype html
+html
+  head
+    title Dummy
+    = stylesheet_link_tag params[:name], media: 'all'
+    = javascript_include_tag params[:name]
+    = csrf_meta_tags
+  body
+    .container
+      = yield

--- a/spec/dummy/app/views/layouts/single_component.slim
+++ b/spec/dummy/app/views/layouts/single_component.slim
@@ -2,7 +2,7 @@ doctype html
 html
   head
     title Dummy
-    = stylesheet_link_tag params[:name], media: 'all'
+    = stylesheet_link_tag 'application', media: 'all'
     = javascript_include_tag params[:name]
     = csrf_meta_tags
   body

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -2,5 +2,6 @@ Rails.application.routes.draw do
   get '/' => 'styleguide#components', as: :styleguide_components
   get '/patterns' => 'styleguide#patterns', as: :styleguide_patterns
   get '/select_async_data' => 'search#search'
+  get '/components/*name/:example_index' => 'components#new_show'
   get '/*name' => 'components#show'
 end

--- a/spec/feature/modal_spec.rb
+++ b/spec/feature/modal_spec.rb
@@ -1,0 +1,26 @@
+RSpec.feature 'Modal component', :js do
+  before do
+    visit '/'
+  end
+
+  scenario 'a simple modal is triggered' do
+    within(all('.modal_component .component')[0]) do
+      expect(page).to_not have_content('Hello!')
+      click_on('Click me!')
+      expect(page).to have_content('Hello!')
+      expect(page).to_not have_css('.modal-footer')
+    end
+  end
+
+  scenario 'a modal with buttons is triggered' do
+    within(all('.modal_component .component')[1]) do
+      expect(page).to_not have_content('Hello!')
+      click_on('Click me!')
+      expect(page).to have_content('Hello!')
+      expect(page).to have_button('Close')
+      expect(page).to have_button('Save')
+      click_on('Close')
+      expect(page).to_not have_content('Hello!')
+    end
+  end
+end

--- a/spec/feature/modal_spec.rb
+++ b/spec/feature/modal_spec.rb
@@ -1,26 +1,22 @@
 RSpec.feature 'Modal component', :js do
-  before do
-    visit '/'
-  end
-
   scenario 'a simple modal is triggered' do
-    within(all('.modal_component .component')[0]) do
-      expect(page).to_not have_content('Hello!')
-      click_on('Click me!')
-      expect(page).to have_content('Hello!')
-      expect(page).to_not have_css('.modal-footer')
-    end
+    visit '/components/modal/0'
+
+    expect(page).to_not have_content('Hello!')
+    click_on('Click me!')
+    expect(page).to have_content('Hello!')
+    expect(page).to_not have_css('.modal-footer')
   end
 
   scenario 'a modal with buttons is triggered' do
-    within(all('.modal_component .component')[1]) do
-      expect(page).to_not have_content('Hello!')
-      click_on('Click me!')
-      expect(page).to have_content('Hello!')
-      expect(page).to have_button('Close')
-      expect(page).to have_button('Save')
-      click_on('Close')
-      expect(page).to_not have_content('Hello!')
-    end
+    visit '/components/modal/1'
+
+    expect(page).to_not have_content('Hello!')
+    click_on('Click me!')
+    expect(page).to have_content('Hello!')
+    expect(page).to have_button('Close')
+    expect(page).to have_button('Save')
+    click_on('Close')
+    expect(page).to_not have_content('Hello!')
   end
 end


### PR DESCRIPTION
Alternative implementation for the integration tests of the modal component (the original one to be found here: #22). Instead of testing the component within the styleguide page, it loads the component individually, without the code of all the other components. Further, it uses the styleguide examples to test against. The pattern should eventually be applied to all the components. This will make sure we can include components into projects individually, instead of all-or-nothing.