### PR TITLE
Use sassc-rails instead of sass-rails

### DIFF
--- a/ui_components.gemspec
+++ b/ui_components.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'cells-slim', '>= 0.0.3'
 
   s.add_dependency 'slim-rails'
-  s.add_dependency 'sass-rails'
+  s.add_dependency 'sassc-rails'
   s.add_dependency 'compass-rails'
   s.add_dependency 'uglifier'
   s.add_dependency 'coffee-rails'


### PR DESCRIPTION
sassc-rails uses libsass (C lib) instead of sass (ruby gem).
It decreases sass compilation time 5x and should be 100% compatible.