### PR TITLE
Remove JS-applied help block CSS

### DIFF
--- a/app/cells/select/select.coffee
+++ b/app/cells/select/select.coffee
@@ -18,14 +18,6 @@ $ ->
 
     $this.chosen data
 
-    # Append help-block to parent .form-group element
-    $formGroup = $this.closest('.form-group')
-    $formGroup.css('position', 'relative')
-    $helpBlock = $formGroup.find('.help-block')
-    $helpBlock.css('position', 'absolute')
-    $helpBlock.css('top', '1.6em')
-    $helpBlock.css('left', '3em')
-
     init_group_selectable($this)
 
     if data.remoteOptions


### PR DESCRIPTION
This causes layout issues in most of our use cases (e.g., with `form-horizontal`) and is difficult to override in the CSS because it's applied to the element directly.

![new_team](https://cloud.githubusercontent.com/assets/670471/10046069/ff1b0202-6206-11e5-8fa4-b4620e1a23b2.png)

I think it should just be applied manually in the target application's CSS in any special cases where it's actually needed.