### PR TITLE
Remove chosen-rails + compass-rails

### DIFF
--- a/app/assets/javascripts/ui_components.js.erb
+++ b/app/assets/javascripts/ui_components.js.erb
@@ -7,7 +7,7 @@
 
 //= require jquery.floatThead/jquery.floatThead
 
-//= require chosen-jquery
+//= require chosen
 //= require ajax-chosen
 //= require bootstrap
 //= require bootstrap-datepicker/core
@@ -19,7 +19,7 @@
 <% UiComponents::Engine.components_paths.each do |path| %>
   <%
     begin
-      require_asset path.basename
+      require_asset path.basename.to_s
     rescue Sprockets::FileNotFound
     end
   %>

--- a/app/assets/stylesheets/a2g_ui_components.scss
+++ b/app/assets/stylesheets/a2g_ui_components.scss
@@ -2,10 +2,7 @@
 @import 'variables';
 @import 'bootstrap';
 
-@import 'bootstrap-datepicker3';
-@import 'bootstrap-daterangepicker';
-
-@import 'bootstrap-chosen';
+@import 'libs';
 
 @import 'ui_components/*';
 @import 'default_theme/*';

--- a/app/assets/stylesheets/libs.scss
+++ b/app/assets/stylesheets/libs.scss
@@ -1,0 +1,6 @@
+@import 'bootstrap-datepicker3';
+@import 'bootstrap-daterangepicker';
+
+$chosen-sprite-path: image-path('chosen/chosen-sprite.png') !default;
+$chosen-sprite-retina-path: image-path('chosen/chosen-sprite@2x.png') !default;
+@import 'bootstrap-chosen';

--- a/app/assets/stylesheets/ui_components.scss.erb
+++ b/app/assets/stylesheets/ui_components.scss.erb
@@ -1,17 +1,14 @@
 @import 'bootstrap-sprockets';
 @import 'bootstrap';
 
-@import 'bootstrap-datepicker3';
-@import 'bootstrap-daterangepicker';
-
-@import 'bootstrap-chosen';
+@import 'libs';
 
 @import 'ui_components/*';
 
 <% UiComponents::Engine.components_paths.each do |path| %>
   <%
     begin
-      require_asset path.basename
+      require_asset path.basename.to_s
     rescue Sprockets::FileNotFound
     end
   %>

--- a/ui_components.gemspec
+++ b/ui_components.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'slim-rails'
   s.add_dependency 'sassc-rails'
-  s.add_dependency 'compass-rails'
   s.add_dependency 'uglifier'
   s.add_dependency 'coffee-rails'
   s.add_dependency 'turbolinks'
@@ -30,7 +29,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'bootstrap-sass'
   s.add_dependency 'bootstrap_form'
   s.add_dependency 'rails_bootstrap_navbar'
-  s.add_dependency 'chosen-rails'
   s.add_dependency 'bootstrap-datepicker-rails'
   s.add_dependency 'rails-assets-bootstrap-daterangepicker', '< 2'
   s.add_dependency 'rails-assets-bootstrap-chosen'


### PR DESCRIPTION
By not using the rails gem for chosen we can
save a lot of space / memory because now we
don't have to load compass or sass-rails.