### PR TITLE
Use input[type=hidden] for date range 'from' and 'to' fields.

### DIFF
--- a/app/cells/date_range/date_range_cell.rb
+++ b/app/cells/date_range/date_range_cell.rb
@@ -20,12 +20,7 @@ class DateRangeCell < FormCellBase
   private
 
   def date_field(type)
-    options[:form].text_field(
-      "#{options[:name]}_#{type}",
-      id: "#{id}_#{type}",
-      skip_label: true,
-      style: 'display: none'
-    )
+    options[:form].hidden_field("#{options[:name]}_#{type}", id: "#{id}_#{type}")
   end
 
   def select_div

--- a/spec/integration/date_range_spec.rb
+++ b/spec/integration/date_range_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'Date Range', :js do
   end
 
   def date(type)
-    find(:fillable_field, "fox[report_range_#{type}]", visible: false).value
+    find("[name='fox[report_range_#{type}]']", visible: false).value
   end
 
   def datepicker(type)


### PR DESCRIPTION
This way extra form groups that take up vertical space aren't created.  It's also a bit simpler. Does anyone know if there's a special reason for the current approach?