### PR TITLE
Remove sassc

### DIFF
--- a/ui_components.gemspec
+++ b/ui_components.gemspec
@@ -21,8 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'cells-slim', '>= 0.0.3'
 
   s.add_dependency 'slim-rails'
-  s.add_dependency 'sassc-rails'
-  s.add_dependency 'sassc', '~> 1.7.0'
+  s.add_dependency 'sass-rails'
   s.add_dependency 'uglifier'
   s.add_dependency 'coffee-rails'
   s.add_dependency 'turbolinks'


### PR DESCRIPTION
sassc caused some issues with include paths and globbing.

So we switch back to sass/sass-rails. The performance impact shouldn't
be that bad. It's more important that it's stable and doesn't break
randomly.