### PR TITLE
Extend date range config options - start/end date, submit-on-change

### DIFF
--- a/app/cells/date_range/date_range.coffee
+++ b/app/cells/date_range/date_range.coffee
@@ -18,10 +18,8 @@ $(document).on 'uic:domchange', (e) ->
 
   defaults = {
     ranges: ranges,
-    startDate: yesterday,
-    endDate: yesterday,
     opens: 'right',
-    format: 'YYYY-MM-DD',
+    format: 'YYYY-MM-DD'
   }
 
   $(e.target).find('.ui-components-date-range').each (_i, el) ->
@@ -29,19 +27,19 @@ $(document).on 'uic:domchange', (e) ->
     $start_input = $($el.data().start)
     $end_input = $($el.data().end)
 
-    start_date = _.find [$start_input.val(), yesterday],
+    start_date = _.find [$el.data('startDate'), $start_input.val(), yesterday],
                         (val) -> val && val.toString().length > 0
-    end_date = _.find [$end_input.val(), yesterday],
+    end_date = _.find [$el.data('endDate'), $end_input.val(), yesterday],
                       (val) -> val && val.toString().length > 0
 
-    start_date = moment(start_date)
-    end_date = moment(end_date)
+    options = _.extend({},
+      defaults,
+      _.pick($el.data(), ['dateLimit', 'ranges']),
+      { startDate: start_date, endDate: end_date })
 
-    options = {}
-    _.extend(options, defaults)
-    _.extend(options, _.pick($el.data(), ['dateLimit', 'ranges']))
-    _.extend(options, { startDate: start_date, endDate: end_date })
     options.ranges = _.mapObject(options.ranges, (v, k) -> _.map(v, (v) -> moment(v)))
+    options.startDate = moment(options.startDate)
+    options.endDate = moment(options.endDate)
 
     callback = (start, end) ->
       end.startOf('day')

--- a/app/cells/date_range/date_range.coffee
+++ b/app/cells/date_range/date_range.coffee
@@ -19,11 +19,13 @@ $(document).on 'uic:domchange', (e) ->
   defaults = {
     ranges: ranges,
     opens: 'right',
-    format: 'YYYY-MM-DD'
+    format: 'YYYY-MM-DD',
+    submitOnChange: false
   }
 
   $(e.target).find('.ui-components-date-range').each (_i, el) ->
     $el = $(el)
+    $form = $el.parents('form')
     $start_input = $($el.data().start)
     $end_input = $($el.data().end)
 
@@ -34,14 +36,14 @@ $(document).on 'uic:domchange', (e) ->
 
     options = _.extend({},
       defaults,
-      _.pick($el.data(), ['dateLimit', 'ranges']),
+      _.pick($el.data(), ['dateLimit', 'ranges', 'submitOnChange']),
       { startDate: start_date, endDate: end_date })
 
     options.ranges = _.mapObject(options.ranges, (v, k) -> _.map(v, (v) -> moment(v)))
     options.startDate = moment(options.startDate)
     options.endDate = moment(options.endDate)
 
-    callback = (start, end) ->
+    reset = (start, end) ->
       end.startOf('day')
 
       $start_input.val(start.format('YYYY-MM-DD'))
@@ -56,6 +58,12 @@ $(document).on 'uic:domchange', (e) ->
         label + ' (' + start.format('YYYY-MM-DD') + ' - ' + end.format('YYYY-MM-DD') + ')'
       )
 
+    callback = (start, end) ->
+      reset(start, end)
+
+      if ($el.data().submitOnChange)
+        $form.submit()
+
     $el.daterangepicker(options, callback)
 
-    callback(options.startDate, options.endDate)
+    reset(options.startDate, options.endDate)

--- a/app/cells/date_range/date_range_cell.rb
+++ b/app/cells/date_range/date_range_cell.rb
@@ -10,6 +10,8 @@ class DateRangeCell < FormCellBase
     'days, months)'
   attribute :start_date, description: 'Default start date'
   attribute :end_date, description: 'Default end date'
+  attribute :submit_on_change, description: 'Whether the enclosing form should be ' \
+    'automatically submitted on value change'
 
   def show
     [
@@ -37,7 +39,7 @@ class DateRangeCell < FormCellBase
   end
 
   def data
-    options.slice(:ranges, :date_limit).merge(
+    options.slice(:ranges, :date_limit, :submit_on_change).merge(
       start_date: start_date.to_s, end_date: end_date.to_s,
       start: "##{id}_from", end: "##{id}_to")
   end

--- a/app/cells/date_range/date_range_cell.rb
+++ b/app/cells/date_range/date_range_cell.rb
@@ -8,6 +8,8 @@ class DateRangeCell < FormCellBase
     'start and end dates. Can have any property you can add to a ' \
     '[moment](http://momentjs.com/docs/#/durations/creating/) object (i.e. ' \
     'days, months)'
+  attribute :start_date, description: 'Default start date'
+  attribute :end_date, description: 'Default end date'
 
   def show
     [
@@ -35,8 +37,9 @@ class DateRangeCell < FormCellBase
   end
 
   def data
-    options.slice(:ranges, :date_limit)
-      .merge(start: "##{id}_from", end: "##{id}_to")
+    options.slice(:ranges, :date_limit).merge(
+      start_date: start_date.to_s, end_date: end_date.to_s,
+      start: "##{id}_from", end: "##{id}_to")
   end
 
   def id

--- a/spec/dummy/app/controllers/components_controller.rb
+++ b/spec/dummy/app/controllers/components_controller.rb
@@ -10,6 +10,10 @@ class ComponentsController < ApplicationController
     render layout: 'single_component'
   end
 
+  def form_submit
+    render json: params
+  end
+
   private
 
   def example_index

--- a/spec/dummy/app/views/components/date_range.html.slim
+++ b/spec/dummy/app/views/components/date_range.html.slim
@@ -1,2 +1,2 @@
-= bootstrap_form_for :fox do |form|
-  = ui_component(:date_range, form: form, name: 'report_range')
+= bootstrap_form_for :my_form do |form|
+  = ui_component(:date_range, form: form, name: 'my_date_range')

--- a/spec/dummy/app/views/components/date_range_custom_ranges.slim
+++ b/spec/dummy/app/views/components/date_range_custom_ranges.slim
@@ -1,5 +1,5 @@
-= bootstrap_form_for :fox do |form|
+= bootstrap_form_for :my_form do |form|
   = ui_component(:date_range,
     form: form,
-    name: 'report_range',
+    name: 'my_date_range',
     ranges: { 'Next 10 days' => [Date.new(2015, 6, 22), Date.new(2015, 7, 1)] })

--- a/spec/dummy/app/views/components/date_range_start_end_date.html.slim
+++ b/spec/dummy/app/views/components/date_range_start_end_date.html.slim
@@ -1,0 +1,6 @@
+= bootstrap_form_for(:my_form, url: '/') do |f|
+  = ui_component 'date_range', form: f,
+                               name: 'my_date_range',
+                               date_limit: { days: 7 },
+                               start_date: Date.new(2016, 1, 1),
+                               end_date: Date.new(2016, 1, 21)

--- a/spec/dummy/app/views/components/date_range_submit_on_change.html.slim
+++ b/spec/dummy/app/views/components/date_range_submit_on_change.html.slim
@@ -1,0 +1,4 @@
+= bootstrap_form_for(:my_form, url: '/form_submit') do |f|
+    = ui_component('date_range', form: f,
+                                 name: 'my_date_range',
+                                 submit_on_change: true)

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -4,4 +4,5 @@ Rails.application.routes.draw do
   get '/select_async_data' => 'search#search'
   get '/components/*name/:example_index' => 'components#new_show'
   get '/*name' => 'components#show'
+  match '/form_submit' => 'components#form_submit', via: :all
 end

--- a/spec/integration/date_range_spec.rb
+++ b/spec/integration/date_range_spec.rb
@@ -78,4 +78,21 @@ RSpec.feature 'Date Range', :js do
     expect(date(:from)).to eq('2016-01-01')
     expect(date(:to)).to eq('2016-01-21')
   end
+
+  scenario 'submits enclosing form on value change' do
+    visit '/date_range_submit_on_change'
+    find('.ui-components-date-range').click
+    find('li', text: 'Custom Range').click
+    within('.calendar.second') do
+      find('td:not(.off)', text: '21').click
+    end
+    within('.calendar.first') do
+      find('td:not(.off)', text: '22').click
+    end
+    click_on 'Apply'
+
+    params = JSON.parse(page.body)['my_form']
+    expect(Date.parse(params['my_date_range_from']).day).to eq(21)
+    expect(Date.parse(params['my_date_range_to']).day).to eq(22)
+  end
 end

--- a/spec/integration/date_range_spec.rb
+++ b/spec/integration/date_range_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'Date Range', :js do
   end
 
   def date(type)
-    find(:fillable_field, "fox[report_range_#{type}]", visible: false).value
+    find(:fillable_field, "my_form[my_date_range_#{type}]", visible: false).value
   end
 
   def datepicker(type)
@@ -68,5 +68,14 @@ RSpec.feature 'Date Range', :js do
     link.click
 
     expect(field.text).to eq('Next 10 days (2015-06-22 - 2015-07-01)')
+  end
+
+  scenario 'start/end dates are configurable' do
+    visit '/date_range_start_end_date'
+    field = find('.ui-components-date-range')
+
+    expect(field.text).to eq('Custom Range (2016-01-01 - 2016-01-21)')
+    expect(date(:from)).to eq('2016-01-01')
+    expect(date(:to)).to eq('2016-01-21')
   end
 end


### PR DESCRIPTION
Pass config options for initial start/end date.
Support *submit-on-change* — submit the enclosing form when the selected date range changes.

Required for https://github.com/ad2games/nevaly/pull/95