### PR TITLE
Allow for modification of passed control_col option

### DIFF
--- a/app/cells/markdown_textarea/markdown_textarea_cell.rb
+++ b/app/cells/markdown_textarea/markdown_textarea_cell.rb
@@ -16,7 +16,7 @@ class MarkdownTextareaCell < FormCellBase
     opts = {
       skip_label: true,
       rows: options[:rows] || 10,
-      control_col: 'col-sm-12',
+      control_col: 'col-sm-12'.dup,
       label_col: '',
       data: { toggle: 'markdown', target: "##{preview_id}" }
     }


### PR DESCRIPTION
In the markdown_textarea cell, when we attempt to build the form group using the provided rails-bootstrap-forms form object, that gem then tries to call `#concat` on our passed-in `control_col` option:

https://github.com/bootstrap-ruby/rails-bootstrap-forms/blob/v2.3.0/lib/bootstrap_form/form_builder.rb#L190

Unfortunately this now fails with the recently added frozen string pragma. To prevent the error we can supply a non-frozen string instead. Hopefully we can get rid of the mutation upstream in the forms gem and this just becomes a temporary solution.