### PR TITLE
Update cells-rails

### DIFF
--- a/ad2games-ui_components.gemspec
+++ b/ad2games-ui_components.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails', '~> 4.2.0'
   s.add_dependency 'cells', '~> 4.1.1'
-  s.add_dependency 'cells-rails', '~> 0.0.4'
+  s.add_dependency 'cells-rails', '~> 0.0.5'
   s.add_dependency 'cells-slim', '>= 0.0.3'
 
   s.add_dependency 'slim-rails'

--- a/lib/ui_components.rb
+++ b/lib/ui_components.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 Gem.loaded_specs['ad2games-ui_components'].dependencies.each do |gem|
-  # TODO: remove when cells-rails follows the gem convention to have a primary file
-  if gem.name == 'cells-rails'
-    require 'cells/rails'
-    next
-  end
   require gem.name if gem.runtime?
 end
 


### PR DESCRIPTION
A new version of cells-rails has been released since yesterday and we don't need the `require`-crutch anymore.