### PR TITLE
Upgrade version constraint of rails dependency

### DIFF
--- a/ad2games-ui_components.gemspec
+++ b/ad2games-ui_components.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
     'README.rdoc'
   ]
 
-  s.add_dependency 'rails', '< 5.1'
+  s.add_dependency 'rails', '>= 4.2', '< 5.1'
   s.add_dependency 'cells', '~> 4.1.1'
   s.add_dependency 'cells-rails', '~> 0.0.5'
   s.add_dependency 'cells-slim', '>= 0.0.3'

--- a/ad2games-ui_components.gemspec
+++ b/ad2games-ui_components.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
     'README.rdoc'
   ]
 
-  s.add_dependency 'rails', '~> 4.2.0'
+  s.add_dependency 'rails', '< 5.1'
   s.add_dependency 'cells', '~> 4.1.1'
   s.add_dependency 'cells-rails', '~> 0.0.5'
   s.add_dependency 'cells-slim', '>= 0.0.3'


### PR DESCRIPTION
It breaks from Rails 5.1 on, but 5.0 would help so I can get the Backoffice there and deploy that. I suppose after that we'll just get rid of `ui_components` and move everything to React.