### PR TITLE
Don't pass max_date min_date when they are not set

### DIFF
--- a/app/cells/date_range/date_range_cell.rb
+++ b/app/cells/date_range/date_range_cell.rb
@@ -52,7 +52,8 @@ class DateRangeCell < FormCellBase
 
   def dates
     %i[start_date end_date min_date max_date].each_with_object({}) do |attribute, hash|
-      hash[attribute] = public_send(attribute).to_s.presence
+      value = public_send(attribute).to_s
+      hash[attribute] = value if value.present?
     end
   end
 

--- a/spec/integration/date_range_spec.rb
+++ b/spec/integration/date_range_spec.rb
@@ -60,6 +60,16 @@ RSpec.feature 'Date Range', :js do
 
     expect(datepicker(:start)).to eq((Time.zone.today - 1.month).beginning_of_month.to_s)
     expect(datepicker(:end)).to eq((Time.zone.today - 1.month).end_of_month.to_s)
+
+    chooser.click
+    select_range 'Custom Range'
+    expect(date(:from)).to eq((Time.zone.today - 1.month).beginning_of_month.to_s)
+    expect(date(:to)).to eq((Time.zone.today - 1.month).end_of_month.to_s)
+    expect(datepicker(:start)).to eq((Time.zone.today - 1.month).beginning_of_month.to_s)
+    expect(datepicker(:end)).to eq((Time.zone.today - 1.month).end_of_month.to_s)
+    within('.calendar.second') do
+      expect(page).to have_selector('.icon-arrow-left')
+    end
   end
 
   scenario 'ranges are configurable' do


### PR DESCRIPTION
This fix monthly arrow navigation links not showing up in calendar when no min_date is set
https://trello.com/c/rCIb64sc